### PR TITLE
Introduce sauna mode flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ This is a customizable application built on three.js that allows users to design
 
 ![3d_design](./images/floorplan3d.png)
 
+## Sauna Planning Mode
+
+The project is gradually evolving into a sauna planning tool. A new configuration flag `projectMode` can be set to `SAUNA` to prepare the application for upcoming sauna specific features. See [docs/SAUNA_MODE.md](docs/SAUNA_MODE.md) for details.
+
+
 ## Developing and Running Locally
 
 To get started, clone the repository and ensure you npm >= 3 and rollup installed, then run:

--- a/docs/SAUNA_MODE.md
+++ b/docs/SAUNA_MODE.md
@@ -1,0 +1,12 @@
+# Sauna Planning Mode
+
+The project can now be configured to run in **sauna** mode. This mode does not change functionality yet but prepares the codebase for future sauna specific features such as custom items and textures.
+
+To enable sauna mode set the `projectMode` configuration value to `SAUNA` before creating the `BlueprintJS` instance:
+
+```javascript
+import { Configuration, configProjectMode } from './core/configuration.js';
+Configuration.setValue(configProjectMode, 'SAUNA');
+```
+
+Future commits can use this flag to load sauna related assets or adjust defaults.

--- a/src/scripts/blueprint.js
+++ b/src/scripts/blueprint.js
@@ -19,7 +19,7 @@ export {ELogContext, ELogLevel, logContext, isLogging, log} from './core/log.js'
 export {dimInch, dimFeetAndInch, dimMeter, dimCentiMeter, dimMilliMeter, dimensioningOptions, decimals, Dimensioning} from './core/dimensioning.js';
 export {cmPerFoot, pixelsPerFoot, cmPerPixel, pixelsPerCm} from './core/dimensioning.js';
 
-export {cornerTolerance, configDimUnit, configWallHeight, configWallThickness, configSystemUI, wallInformation, scale, snapToGrid, snapTolerance, gridSpacing, config, Configuration} from './core/configuration.js';
+export {cornerTolerance, configDimUnit, configWallHeight, configWallThickness, configSystemUI, wallInformation, scale, snapToGrid, snapTolerance, gridSpacing, configProjectMode, config, Configuration} from './core/configuration.js';
 export {VIEW_TOP, VIEW_FRONT, VIEW_RIGHT, VIEW_LEFT, VIEW_ISOMETRY} from './core/constants.js';
 export {WallTypes} from './core/constants.js';
 
@@ -77,7 +77,7 @@ export {OBJExporter} from './exporters/OBJExporter.js';
 import {Model} from './model/model.js';
 import {Main} from './three/main.js';
 import {Floorplanner2D} from './floorplanner/floorplanner.js';
-import {Configuration, configDimUnit} from './core/configuration.js';
+import {Configuration, configDimUnit, configProjectMode} from './core/configuration.js';
 import {dimMeter} from './core/dimensioning.js';
 //
 ///** VestaDesigner core application. */

--- a/src/scripts/core/configuration.js
+++ b/src/scripts/core/configuration.js
@@ -17,8 +17,10 @@ export const scale = 'scale';
 export const gridSpacing = 'gridSpacing';
 export const snapToGrid = 'snapToGrid';
 export const snapTolerance = 'snapTolerance';//In CMS
+/** Project type indicator to help customize the application. */
+export const configProjectMode = 'projectMode';
 
-export var config = {dimUnit: dimCentiMeter, wallHeight: 250, wallThickness: 10, systemUI: false, scale: 1, snapToGrid: false, snapTolerance: 25, gridSpacing: 25};
+export var config = {dimUnit: dimCentiMeter, wallHeight: 250, wallThickness: 10, systemUI: false, scale: 1, snapToGrid: false, snapTolerance: 25, gridSpacing: 25, projectMode: 'DEFAULT'};
 
 export var wallInformation = {exterior: false, interior: false, midline: true, labels: true, exteriorlabel:'e:', interiorlabel:'i:', midlinelabel:'m:'};
 
@@ -57,6 +59,8 @@ export class Configuration
 		case configDimUnit:
 //			return String(this.data[key]);
 			return String(Configuration.getData()[key]);
+                case configProjectMode:
+                        return String(Configuration.getData()[key]);
 		default:
 			throw new Error('Invalid string configuration parameter: ' + key);
 		}

--- a/src/scripts/core/constants.js
+++ b/src/scripts/core/constants.js
@@ -7,3 +7,7 @@ export const VIEW_LEFT = 'leftview';
 export const VIEW_ISOMETRY = 'isometryview';
 
 export const WallTypes = Enum('STRAIGHT', 'CURVED');
+
+/** Modes describing what type of project this instance is used for. */
+export const ProjectModes = Enum('DEFAULT', 'SAUNA');
+


### PR DESCRIPTION
## Summary
- add `ProjectModes` enum for future customization
- extend global configuration with `projectMode`
- export the new flag from the BlueprintJS entrypoint
- document how to enable sauna mode

## Testing
- `npm test` *(fails: Error: no test specified)*