### PR TITLE
Add interior cladding defaults

### DIFF
--- a/src/scripts/core/configuration.js
+++ b/src/scripts/core/configuration.js
@@ -19,8 +19,10 @@ export const snapToGrid = 'snapToGrid';
 export const snapTolerance = 'snapTolerance';//In CMS
 /** Project type indicator to help customize the application. */
 export const configProjectMode = 'projectMode';
+/** Default reveal width for horizontal cladding boards in cm */
+export const configWallCladdingReveal = 'wallCladdingReveal';
 
-export var config = {dimUnit: dimCentiMeter, wallHeight: 250, wallThickness: 10, systemUI: false, scale: 1, snapToGrid: false, snapTolerance: 25, gridSpacing: 25, projectMode: 'DEFAULT'};
+export var config = {dimUnit: dimCentiMeter, wallHeight: 250, wallThickness: 10, systemUI: false, scale: 1, snapToGrid: false, snapTolerance: 25, gridSpacing: 25, projectMode: 'DEFAULT', wallCladdingReveal: 8.128};
 
 export var wallInformation = {exterior: false, interior: false, midline: true, labels: true, exteriorlabel:'e:', interiorlabel:'i:', midlinelabel:'m:'};
 
@@ -78,6 +80,7 @@ export class Configuration
 		case snapToGrid:
 		case snapTolerance:
 		case gridSpacing:
+                case configWallCladdingReveal:
 //			return Number(this.data[key]);
 			return Number(Configuration.getData()[key]);
 		default:


### PR DESCRIPTION
## Summary
- allow configuration of cladding reveal width
- render interior walls with separate board meshes
- approximate roof as rows of boards

## Testing
- `npm run build` *(fails: rollup not found)*
- `npm test` *(fails: no test specified)*